### PR TITLE
Clarify supported MQTT versions

### DIFF
--- a/src/mqtt.md
+++ b/src/mqtt.md
@@ -12,6 +12,10 @@ ActiveMQ supports the [MQTT](http://mqtt.org/) protocol and will automatically m
 
 Please see the [MQTT site](http://mqtt.org/) for more details
 
+### Supported versions
+
+ActiveMQ supports MQTT [v3.1.1](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html) and [v3.1](https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html).
+
 ### Enabling the ActiveMQ Broker for MQTT
 
 Its very easy to enable ActiveMQ for MQTT. Just add a connector to the broker using the MQTT URL.


### PR DESCRIPTION
We (Amazon MQ) could not find if ActiveMQ Classic supports MQTT v3.1 or 3.1.1 or both. Based on this [Jira ticket](https://issues.apache.org/jira/browse/AMQ-4990) and the tests [here](https://github.com/apache/activemq/blob/main/activemq-mqtt/src/test/java/org/apache/activemq/transport/mqtt/MQTTTest.java) it seems that it supports both 3.1 and 3.1.1.